### PR TITLE
introduce a zero-arg constructor in place of the `undef` constructors

### DIFF
--- a/src/ZeroDimensionalArrays.jl
+++ b/src/ZeroDimensionalArrays.jl
@@ -116,7 +116,7 @@ for Arr ∈ (
     end
 end
 
-function ZeroDimensionalArrayMutable{T}(::UndefInitializer, ::Tuple{} = ()) where {T}
+function ZeroDimensionalArrayMutable{T}() where {T}
     new_zero_dimensional_array_mutable_undef(T)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,8 +45,7 @@ using Aqua: Aqua
         @testset "`ZeroDimensionalArrayMutable`" begin
             @test @isdefined ZeroDimensionalArrayMutable
             @test ismutabletype(ZeroDimensionalArrayMutable)
-            @test (@inferred ZeroDimensionalArrayMutable{Float32}(undef)) isa ZeroDimensionalArrayMutable{Float32}
-            @test (@inferred ZeroDimensionalArrayMutable{Float32}(undef, ())) isa ZeroDimensionalArrayMutable{Float32}
+            @test (@inferred ZeroDimensionalArrayMutable{Float32}()) isa ZeroDimensionalArrayMutable{Float32}
             @test let a = ZeroDimensionalArrayMutable(fill(0.3))
                 a[] = 0.7
                 only(a) === 0.7


### PR DESCRIPTION
Do it like `Ref` does it instead of like `Array` does it.