### PR TITLE
introduce "boxing" constructors in place of converting ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The motivation for creating this package is:
     * `ZeroDimensionalArrayMutable` can be a good replacement. Examples:
         * make a `const` binding that's mutable:
           ```julia
-          const some_const_binding = ZeroDimensionalArrayMutable(fill(0.2))
+          const some_const_binding = ZeroDimensionalArrayMutable(0.2)
           ```
         * make a field within an immutable `struct` mutable (warning: it's usually more efficient to change the entire `struct` into a `mutable struct`)
           ```julia
@@ -45,11 +45,11 @@ The motivation for creating this package is:
         * https://github.com/JuliaLang/julia/issues/40369
         * https://discourse.julialang.org/t/dynamic-immutable-type/127168
 * to provide a wrapper type for treating a value as a scalar in broadcasting, something `Ref` is often used for:
-    * `ZeroDimensionalArrayImmutable` can be a good replacement. Construct one from its only element using the `wrap_in_0dim` function. Like this:
+    * `ZeroDimensionalArrayImmutable` can be a good replacement:
       ```julia-repl
       julia> using ZeroDimensionalArrays
 
-      julia> isa.(wrap_in_0dim([1,2,3]), [Array, Dict, Int])
+      julia> isa.(ZeroDimensionalArrayImmutable([1,2,3]), [Array, Dict, Int])
       3-element BitVector:
        1
        0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,25 +13,26 @@ using Aqua: Aqua
             ZeroDimensionalArrayMutable,
             ZeroDimensionalArrayMutableConstField,
         )
+            @test (@inferred Arr(0.3)) == (@inferred convert(Arr, fill(0.3)))
             @test isstructtype(Arr)
             @test Arr <: AbstractArray{<:Any, 0}
-            @test (@inferred Arr(fill(0.3))) isa Arr{Float64}
+            @test (@inferred Arr(0.3)) isa Arr{Float64}
             @test (@inferred convert(Arr, fill(0.3))) isa Arr{Float64}
-            @test (@inferred Arr{Float32}(fill(0.3))) isa Arr{Float32}
+            @test (@inferred Arr{Float32}(0.3)) isa Arr{Float32}
             @test (@inferred convert(Arr{Float32}, fill(0.3))) isa Arr{Float32}
-            @test () === @inferred propertynames(Arr(fill(0.3)))
-            @test only(fill(0.3)) === @inferred only(Arr(fill(0.3)))
-            @test fill(0.3)[] === @inferred Arr(fill(0.3))[]
-            @test fill(0.3)[1] === @inferred Arr(fill(0.3))[1]
-            @test @inferred isassigned(Arr(fill(0.3)))
-            @test @inferred isassigned(Arr(fill(0.3)), 1)
-            @test !(isassigned(Arr(fill(0.3)), 2))
-            @test (@inferred similar(Arr(fill(0.3)))) isa ZeroDimensionalArrayMutable{Float64}
-            @test (@inferred similar(Arr(fill(0.3)), Float32)) isa ZeroDimensionalArrayMutable{Float32}
-            @test fill(0.3) == Arr(fill(0.3))
-            @test Arr(fill(0.3)) == Arr(fill(0.3))
-            @test all(@inferred Arr(fill(0.3)) .== Arr(fill(0.3)))
-            @test (@inferred Arr(fill(0.3)) .+ [10, 20]) isa AbstractVector
+            @test () === @inferred propertynames(Arr(0.3))
+            @test only(fill(0.3)) === @inferred only(Arr(0.3))
+            @test fill(0.3)[] === @inferred Arr(0.3)[]
+            @test fill(0.3)[1] === @inferred Arr(0.3)[1]
+            @test @inferred isassigned(Arr(0.3))
+            @test @inferred isassigned(Arr(0.3), 1)
+            @test !(isassigned(Arr(0.3), 2))
+            @test (@inferred similar(Arr(0.3))) isa ZeroDimensionalArrayMutable{Float64}
+            @test (@inferred similar(Arr(0.3), Float32)) isa ZeroDimensionalArrayMutable{Float32}
+            @test fill(0.3) == Arr(0.3)
+            @test Arr(0.3) == Arr(0.3)
+            @test all(@inferred Arr(0.3) .== Arr(0.3))
+            @test (@inferred Arr(0.3) .+ [10, 20]) isa AbstractVector
         end
     end
 
@@ -40,13 +41,12 @@ using Aqua: Aqua
             @test @isdefined ZeroDimensionalArrayImmutable
             @test !ismutabletype(ZeroDimensionalArrayImmutable)
             @test isbitstype(ZeroDimensionalArrayImmutable{Float64})
-            @test ZeroDimensionalArrayImmutable(fill(7)) === @inferred wrap_in_0dim(7)
         end
         @testset "`ZeroDimensionalArrayMutable`" begin
             @test @isdefined ZeroDimensionalArrayMutable
             @test ismutabletype(ZeroDimensionalArrayMutable)
             @test (@inferred ZeroDimensionalArrayMutable{Float32}()) isa ZeroDimensionalArrayMutable{Float32}
-            @test let a = ZeroDimensionalArrayMutable(fill(0.3))
+            @test let a = ZeroDimensionalArrayMutable(0.3)
                 a[] = 0.7
                 only(a) === 0.7
             end


### PR DESCRIPTION
Do it like `Fill` from FillArrays.jl does it, instead of like `Array` does it.

This also makes `wrap_in_0dim` redundant, so delete it.