### PR TITLE
`copy`: return a value of the same type

### DIFF
--- a/src/ZeroDimensionalArrays.jl
+++ b/src/ZeroDimensionalArrays.jl
@@ -95,6 +95,11 @@ function convert_from_other_array(::Type{Arr}, a::AbstractArray{<:Any, 0}) where
     convert_from_other_array_to_given_eltype(Arr, T, a)
 end
 
+function Base.copy(a::ZeroDimensionalArray)
+    Arr = typeof(a)
+    convert_from_other_array(Arr, a)
+end
+
 for Arr ∈ (
     ZeroDimArray,
     Box,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,11 @@ using Aqua: Aqua
             @test !(isassigned(Arr(0.3), 2))
             @test (@inferred similar(Arr(0.3))) isa Box{Float64}
             @test (@inferred similar(Arr(0.3), Float32)) isa Box{Float32}
+            @test (@inferred copy(Arr(0.3))) isa Arr{Float64}
+            @test (@inferred copy(Arr{AbstractFloat}(0.3))) isa Arr{AbstractFloat}
+            @test let a = Arr(0.3)
+                a == copy(a)
+            end
             @test fill(0.3) == Arr(0.3)
             @test Arr(0.3) == Arr(0.3)
             @test all(@inferred Arr(0.3) .== Arr(0.3))


### PR DESCRIPTION
Before this the return type was always `Box`.