### PR TITLE
Implement scalar zero dimensional array that is accessed atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Exports these zero-dimensional subtypes of `AbstractArray`, differing on topics 
 
 * `ZeroDimArrayInTypeParameter`
 
+* `Atomic`
+
 See their doc strings for more info!
 
 Any zero-dimensional array is an iterator containing exactly one element (this follows from the zero-dimensional shape). `Ref`, too, is a zero-dimensional iterator, however it's not an array. Even though `Ref` supports being indexed like a zero-dimensional array is commonly indexed, without an index: `x[]`.

--- a/src/ZeroDimensionalArrays.jl
+++ b/src/ZeroDimensionalArrays.jl
@@ -295,12 +295,15 @@ function Base.getindex(a::ZeroDimensionalArray)
         Value
     end
     local ret
-    if a isa Union{ZeroDimArray, Box, BoxConst, Atomic}
+    if a isa Union{ZeroDimArray, Box, BoxConst}
         ret = a.v
     elseif a isa ZeroDimArrayInTypeParameter
         ret = get_param(a)
     end
     ret
+end
+function Base.getindex(a::Atomic)
+    @atomic a.v
 end
 
 # This method is redundant for correctness, but adding it helps achieve constprop, which

--- a/src/ZeroDimensionalArrays.jl
+++ b/src/ZeroDimensionalArrays.jl
@@ -1,6 +1,7 @@
 module ZeroDimensionalArrays
 
 export
+    Atomic,
     ZeroDimArray,
     ZeroDimArrayInTypeParameter,
     Box,
@@ -40,6 +41,8 @@ array, subtyping `AbstractArray{T, 0} where {T}`.
 
 Other exported collection types:
 
+* [`Atomic`](@ref)
+
 * [`Box`](@ref)
 
 * [`BoxConst`](@ref)
@@ -78,6 +81,8 @@ array, subtyping `AbstractArray{T, 0} where {T}`.
 * Regarding layout in memory, a `Box` is a reference to its element.
 
 Other exported collection types:
+
+* [`Atomic`](@ref)
 
 * [`BoxConst`](@ref)
 
@@ -122,6 +127,8 @@ array, subtyping `AbstractArray{T, 0} where {T}`.
 * Regarding layout in memory, a `BoxConst` is a reference to its element.
 
 Other exported collection types:
+
+* [`Atomic`](@ref)
 
 * [`Box`](@ref)
 
@@ -179,6 +186,8 @@ array, subtyping `AbstractArray{T, 0} where {T}`.
 
 Other exported collection types:
 
+* [`Atomic`](@ref)
+
 * [`Box`](@ref)
 
 * [`BoxConst`](@ref)
@@ -196,6 +205,51 @@ struct ZeroDimArrayInTypeParameter{T, Value} <: AbstractZeroDimensionalArray{T}
     end
 end
 
+"""
+    Atomic
+
+A collection type storing exactly one element. More precisely, a zero-dimensional
+array, subtyping `AbstractArray{T, 0} where {T}`.
+
+* Has a single type parameter:
+
+    * `T`, the element type
+
+* Construct like so:
+
+    * `Atomic(element)`
+
+    * `Atomic{T}(element)`
+
+* Convert from other array types with `convert`.
+
+* After a `Atomic` is constructed, change the value of its element using `setindex!`.
+  Julia supports the square bracket syntax for `setindex!`: `array[] = element` is
+  equivalent to `setindex!(array, element)`.
+
+* Regarding layout in memory, a `Atomic` is a reference to its element.
+
+Other exported collection types:
+
+* [`Box`](@ref)
+
+* [`BoxConst`](@ref)
+
+* [`ZeroDimArray`](@ref)
+
+* [`ZeroDimArrayInTypeParameter`](@ref)
+
+"""
+mutable struct Atomic{T} <: AbstractZeroDimensionalArray{T}
+    @atomic v::T
+    global function new_zero_dimensional_array_atomic(::Type{T}, v) where {T}
+        new{T}(v)
+    end
+    global function new_zero_dimensional_array_atomic_undef(::Type{T}) where {T}
+        new{T}()
+    end
+end
+
 const ZeroDimensionalArrayCanNotMutateElement = Union{
     ZeroDimArray,
     ZeroDimArrayInTypeParameter,
@@ -205,6 +259,7 @@ const ZeroDimensionalArrayCanNotMutateElement = Union{
 const ZeroDimensionalArray = Union{
     ZeroDimensionalArrayCanNotMutateElement,
     Box,
+    Atomic,
 }
 
 function type_to_constructor_function(::Type{T}) where {T <: ZeroDimensionalArray}
@@ -217,6 +272,8 @@ function type_to_constructor_function(::Type{T}) where {T <: ZeroDimensionalArra
         ret = new_zero_dimensional_array_mutable
     elseif T <: BoxConst
         ret = new_zero_dimensional_array_mutable_const_field
+    elseif T <: Atomic
+        ret = new_zero_dimensional_array_atomic
     end
     ret
 end
@@ -238,7 +295,7 @@ function Base.getindex(a::ZeroDimensionalArray)
         Value
     end
     local ret
-    if a isa Union{ZeroDimArray, Box, BoxConst}
+    if a isa Union{ZeroDimArray, Box, BoxConst, Atomic}
         ret = a.v
     elseif a isa ZeroDimArrayInTypeParameter
         ret = get_param(a)
@@ -258,6 +315,12 @@ end
 function Base.setindex!(a::Box, x)
     a.v = x
 end
+
+function Base.setindex!(a::Atomic, x)
+    @atomic a.v = x
+end
+
+
 
 Base.@nospecializeinfer function Base.isassigned((@nospecialize unused::ZeroDimensionalArray), i::Vararg{Integer})
     all(isone, i)
@@ -284,7 +347,7 @@ function construct_given_eltype(::Type{Arr}, ::Type{T}, v) where {Arr <: ZeroDim
 end
 
 function construct(::Type{Arr}, v) where {Arr <: ZeroDimensionalArray}
-    T = if (!(Arr <: Box)) && (v isa Type)
+    T = if (!(Arr <: Union{Box, Atomic})) && (v isa Type)
         Type{v}
     else
         typeof(v)
@@ -308,6 +371,7 @@ function Base.copy(a::ZeroDimensionalArray)
 end
 
 for Arr ∈ (
+    Atomic,
     ZeroDimArray,
     ZeroDimArrayInTypeParameter,
     Box,
@@ -327,6 +391,10 @@ for Arr ∈ (
             construct_given_eltype($Arr, T, v)
         end
     end
+end
+
+function Atomic{T}() where {T}
+    new_zero_dimensional_array_atomic_undef(T)
 end
 
 function Box{T}() where {T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using Test
     @testset "all array types joined" begin
         x = 0.3
         for Arr ∈ (
+            Atomic,
             ZeroDimArray,
             ZeroDimArrayInTypeParameter,
             Box,
@@ -102,6 +103,20 @@ using Test
                 only(a) === Float32
             end
         end
+        @testset "`Atomic`" begin
+            @test @isdefined Atomic
+            @test ismutabletype(Atomic)
+            @test (@inferred Atomic{Float32}()) isa Atomic{Float32}
+            @test let a = Atomic(0.3)
+                a[] = 0.7
+                only(a) === 0.7
+            end
+            @test let a = Atomic(Int)
+                a[] = Float32
+                only(a) === Float32
+            end
+        end
+
         @testset "`BoxConst`" begin
             @test @isdefined BoxConst
             @test ismutabletype(BoxConst)


### PR DESCRIPTION
This provides another zero dim type with that is accessed atomically. It is admittedly lacking some API for fing grain control over access order, but I'm not sure if that's desirable at this point since Base Julia has yet to commit to a public API for extending that behavior to reference semantics.